### PR TITLE
feat: Add Registry Developer Account Registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ flb set-auth [token] --path /fleetbase
 
 - `-p, --path`: (Optional) The path to the fleetbase instance directory. Defaults to the current directory.
 
+### Login to the Fleetbase Registry
+
+Login to the Fleetbase registry. This command authenticates you with the Fleetbase registry by saving your credentials to your local `.npmrc` file.
+
+```bash
+flb login [options]
+```
+
+- `-u, --username <username>`: Username for the registry.
+- `-p, --password <password>`: Password for the registry.
+- `-e, --email <email>`: Email associated with your account.
+- `-r, --registry <registry>`: Registry URL (default: `https://registry.fleetbase.io`).
+- `--scope <scope>`: Scope for the registry (optional).
+- `--quotes <quotes>`: Quotes option for `npm-cli-login` (optional).
+- `--config-path <configPath>`: Path to the npm config file (optional).
+
 ### Scaffolding a Extension
 
 Fleetbase CLI has the ability to scaffold a starter extension if you intend to develop your own extension. This greatly speeds up the development process as it gives you a correct starting point to build on.
@@ -96,6 +112,52 @@ flb uninstall [extension] --path /fleetbase
 
 - `[extension]`: The name of the extension to install.
 - `-p, --path`: (Optional) The path to the fleetbase instance directory. Defaults to the current directory.
+
+### Bundling a Extension
+
+To bundle a extension, use: 
+
+```bash
+flb bundle
+```
+
+or to bundle and upload the created bundle, use:
+
+```bash
+flb bundle --upload
+```
+
+- `-p, --path <path>`: Path of the Fleetbase extension (default: `.`).
+- `--upload`: After bundling, upload the bundle to the Fleetbase registry using your authentication token.
+- `--auth-token <token>`: Auth token for uploading the bundle (used with `--upload` option).
+- `-r, --registry <registry>`: Registry URL (default: `https://registry.fleetbase.io`).
+
+### Uploading a Extension Bundle
+
+To upload an extension bundle, use:
+
+```bash
+flb bundle-upload
+```
+
+- `[bundleFile]`: Path to the bundle file to upload. If not provided, it will look for the bundle in the current directory.
+- `-p, --path <path>`: Path where the bundle is located (default: `.`).
+- `--auth-token <token>`: Auth token for uploading the bundle. If not provided, the token will be read from the `.npmrc` file.
+- `-r, --registry <registry>`: Registry URL (default: `https://registry.fleetbase.io`).
+
+### Version Bump and Extension
+
+To bump the version on an extension, use:
+
+```bash
+flb version-bump
+```
+
+- `-p, --path <path>`: Path of the Fleetbase extension (default: `.`).
+- `--major`: Bump major version (e.g., `1.0.0` → `2.0.0`).
+- `--minor`: Bump minor version (e.g., `1.0.0` → `1.1.0`).
+- `--patch`: Bump patch version (e.g., `1.0.0` → `1.0.1`). This is the default if no flag is provided.
+- `--pre-release [identifier]`: Add a pre-release identifier (e.g., `1.0.0` → `1.0.0-beta`).
 
 ### Setting a Custom Registry
 

--- a/index.js
+++ b/index.js
@@ -721,7 +721,102 @@ async function versionBump (options) {
     }
 }
 
-// Command to handle login
+// Command to handle registration
+async function registerCommand(options) {
+    const registrationApi = 'https://api.fleetbase.io/~registry/v1/developer-account/register';
+    
+    try {
+        // Collect registration information
+        const answers = await prompt([
+            {
+                type: 'input',
+                name: 'username',
+                message: 'Username:',
+                initial: options.username,
+                skip: !!options.username,
+                validate: (value) => {
+                    if (!value || value.length < 3) {
+                        return 'Username must be at least 3 characters';
+                    }
+                    if (!/^[a-zA-Z0-9_-]+$/.test(value)) {
+                        return 'Username can only contain letters, numbers, hyphens, and underscores';
+                    }
+                    return true;
+                }
+            },
+            {
+                type: 'input',
+                name: 'email',
+                message: 'Email:',
+                initial: options.email,
+                skip: !!options.email,
+                validate: (value) => {
+                    if (!value || !value.includes('@')) {
+                        return 'Please enter a valid email address';
+                    }
+                    return true;
+                }
+            },
+            {
+                type: 'password',
+                name: 'password',
+                message: 'Password:',
+                skip: !!options.password,
+                validate: (value) => {
+                    if (!value || value.length < 8) {
+                        return 'Password must be at least 8 characters';
+                    }
+                    return true;
+                }
+            },
+            {
+                type: 'input',
+                name: 'name',
+                message: 'Full Name (optional):',
+                initial: options.name
+            }
+        ]);
+
+        const registrationData = {
+            username: options.username || answers.username,
+            email: options.email || answers.email,
+            password: options.password || answers.password,
+            name: options.name || answers.name || undefined
+        };
+
+        console.log('\nRegistering account...');
+
+        // Make API call to register
+        const response = await axios.post(registrationApi, registrationData);
+
+        if (response.data.status === 'success') {
+            console.log('\n✓ Account created successfully!');
+            console.log('✓ Please check your email to verify your account.');
+            console.log(`\n✓ Once verified, you can login with: flb login -u ${registrationData.username}`);
+        } else {
+            console.error('Registration failed:', response.data.message || 'Unknown error');
+            process.exit(1);
+        }
+    } catch (error) {
+        if (error.response && error.response.data) {
+            const errorData = error.response.data;
+            if (errorData.errors) {
+                console.error('\nRegistration failed with the following errors:');
+                Object.keys(errorData.errors).forEach(field => {
+                    errorData.errors[field].forEach(message => {
+                        console.error(`  - ${field}: ${message}`);
+                    });
+                });
+            } else {
+                console.error('Registration failed:', errorData.message || 'Unknown error');
+            }
+        } else {
+            console.error('Registration failed:', error.message);
+        }
+        process.exit(1);
+    }
+}
+
 function loginCommand (options) {
     const npmLogin = require('npm-cli-login');
     const username = options.username;
@@ -874,6 +969,15 @@ program
     .option('--patch', 'Bump patch version')
     .option('--pre-release [identifier]', 'Add pre-release identifier')
     .action(versionBump);
+
+program
+    .command('register')
+    .description('Register a new Registry Developer Account')
+    .option('-u, --username <username>', 'Username for the registry')
+    .option('-e, --email <email>', 'Email address')
+    .option('-p, --password <password>', 'Password')
+    .option('-n, --name <name>', 'Your full name (optional)')
+    .action(registerCommand);
 
 program
     .command('login')


### PR DESCRIPTION
## Overview

This PR adds the `flb register` command to enable users to create Registry Developer Accounts directly from the CLI.

## Changes

### New Command: `flb register`

Adds a new registration command with the following features:

- **Interactive prompts** for username, email, password, and optional full name
- **Input validation**:
  - Username: min 3 characters, alphanumeric with hyphens/underscores only
  - Email: valid email format required
  - Password: min 8 characters required
- **API integration**: Calls `POST /~registry/v1/developer-account/register`
- **Error handling**: Displays validation errors from API responses
- **User guidance**: Provides clear next steps after successful registration

### Usage

```bash
# Interactive mode
flb register

# With options
flb register -u myusername -e user@example.com -p mypassword -n "John Doe"
```

### Output Example

```
✓ Account created successfully!
✓ Please check your email to verify your account.

✓ Once verified, you can login with: flb login -u myusername
```

## Benefits

✅ Seamless onboarding for self-hosted users
✅ No need to visit web interface for registration
✅ Consistent CLI experience
✅ Clear validation and error messages

## Testing

- [ ] Test interactive registration flow
- [ ] Test registration with command-line options
- [ ] Test validation error handling
- [ ] Test API error handling
- [ ] Test success message and guidance

## Related

This PR works in conjunction with the registry-bridge PR #27 that implements the backend support for Registry Developer Accounts.